### PR TITLE
openpgp: mark as deprecated

### DIFF
--- a/openpgp/armor/armor.go
+++ b/openpgp/armor/armor.go
@@ -4,6 +4,12 @@
 
 // Package armor implements OpenPGP ASCII Armor, see RFC 4880. OpenPGP Armor is
 // very similar to PEM except that it has an additional CRC checksum.
+//
+// Deprecated: this package is unmaintained except for security fixes. New
+// applications should consider a more focused, modern alternative to OpenPGP
+// for their specific task. If you are required to interoperate with OpenPGP
+// systems and need a maintained package, consider a maintained community fork.
+// See https://golang.org/issue/37497.
 package armor // import "golang.org/x/crypto/openpgp/armor"
 
 import (

--- a/openpgp/clearsign/clearsign.go
+++ b/openpgp/clearsign/clearsign.go
@@ -7,6 +7,12 @@
 //
 // Clearsigned messages are cryptographically signed, but the contents of the
 // message are kept in plaintext so that it can be read without special tools.
+//
+// Deprecated: this package is unmaintained except for security fixes. New
+// applications should consider a more focused, modern alternative to OpenPGP
+// for their specific task. If you are required to interoperate with OpenPGP
+// systems and need a maintained package, consider a maintained community fork.
+// See https://golang.org/issue/37497.
 package clearsign // import "golang.org/x/crypto/openpgp/clearsign"
 
 import (

--- a/openpgp/elgamal/elgamal.go
+++ b/openpgp/elgamal/elgamal.go
@@ -10,6 +10,12 @@
 // This form of ElGamal embeds PKCS#1 v1.5 padding, which may make it
 // unsuitable for other protocols. RSA should be used in preference in any
 // case.
+//
+// Deprecated: this package was only provided to support ElGamal encryption in
+// OpenPGP. The golang.org/x/crypto/openpgp package is now deprecated (see
+// https://golang.org/issue/44226), and ElGamal in the OpenPGP ecosystem has
+// compatibility and security issues (see https://eprint.iacr.org/2021/923).
+// Moreover, this package doesn't protect against side-channel attacks.
 package elgamal // import "golang.org/x/crypto/openpgp/elgamal"
 
 import (

--- a/openpgp/errors/errors.go
+++ b/openpgp/errors/errors.go
@@ -3,6 +3,12 @@
 // license that can be found in the LICENSE file.
 
 // Package errors contains common error types for the OpenPGP packages.
+//
+// Deprecated: this package is unmaintained except for security fixes. New
+// applications should consider a more focused, modern alternative to OpenPGP
+// for their specific task. If you are required to interoperate with OpenPGP
+// systems and need a maintained package, consider a maintained community fork.
+// See https://golang.org/issue/37497.
 package errors // import "golang.org/x/crypto/openpgp/errors"
 
 import (

--- a/openpgp/packet/packet.go
+++ b/openpgp/packet/packet.go
@@ -4,6 +4,12 @@
 
 // Package packet implements parsing and serialization of OpenPGP packets, as
 // specified in RFC 4880.
+//
+// Deprecated: this package is unmaintained except for security fixes. New
+// applications should consider a more focused, modern alternative to OpenPGP
+// for their specific task. If you are required to interoperate with OpenPGP
+// systems and need a maintained package, consider a maintained community fork.
+// See https://golang.org/issue/37497.
 package packet // import "golang.org/x/crypto/openpgp/packet"
 
 import (

--- a/openpgp/read.go
+++ b/openpgp/read.go
@@ -3,6 +3,12 @@
 // license that can be found in the LICENSE file.
 
 // Package openpgp implements high level operations on OpenPGP messages.
+//
+// Deprecated: this package is unmaintained except for security fixes. New
+// applications should consider a more focused, modern alternative to OpenPGP
+// for their specific task. If you are required to interoperate with OpenPGP
+// systems and need a maintained package, consider a maintained community fork.
+// See https://golang.org/issue/37497.
 package openpgp // import "golang.org/x/crypto/openpgp"
 
 import (

--- a/openpgp/s2k/s2k.go
+++ b/openpgp/s2k/s2k.go
@@ -4,11 +4,16 @@
 
 // Package s2k implements the various OpenPGP string-to-key transforms as
 // specified in RFC 4800 section 3.7.1.
-
+//
 // Modifications from patches written by:
 //    Fan Jiang <fanjiang@thoughtworks.com> and
 //    Sofia Celi <sceli@thoughtworks.com>
-
+//
+// Deprecated: this package is unmaintained except for security fixes. New
+// applications should consider a more focused, modern alternative to OpenPGP
+// for their specific task. If you are required to interoperate with OpenPGP
+// systems and need a maintained package, consider a maintained community fork.
+// See https://golang.org/issue/37497.
 package s2k // import "golang.org/x/crypto/openpgp/s2k"
 
 import (


### PR DESCRIPTION
Cherry pick package deprecation commit from upstream (https://github.com/golang/crypto/commit/0ba0e8f031222feafe2c6fe04ba9c3da11dd361a). 